### PR TITLE
provide explicit serde feature

### DIFF
--- a/nexosim/Cargo.toml
+++ b/nexosim/Cargo.toml
@@ -41,6 +41,7 @@ server = [
     "dep:tonic",
     "tai-time/serde",
 ]
+serde = ["dep:serde"]
 tracing = ["dep:tracing", "dep:tracing-subscriber"]
 
 # DEVELOPMENT ONLY: API-unstable public exports meant for external test/benchmarking.


### PR DESCRIPTION
Right now, I can not use/enable the `serde` feature of nexosim.

As specified [here](https://doc.rust-lang.org/cargo/reference/features.html)

> In some cases, you may not want to expose a feature that has the same name as the optional dependency. For example, perhaps the optional dependency is an internal detail, or you want to group multiple optional dependencies together, or you just want to use a better name. If you specify the optional dependency with the dep: prefix anywhere in the [features] table, that disables the implicit feature.

Which means that an explicit serde feature is required. This might also be an issue for some other optional dependencies which also serve as features?