### PR TITLE
Enable gRPC server to handle concurrent requests

### DIFF
--- a/nexosim/Cargo.toml
+++ b/nexosim/Cargo.toml
@@ -70,10 +70,7 @@ ciborium = { version = "0.2.2", optional = true }
 prost = { version = "0.13", optional = true }
 prost-types = { version = "0.13", optional = true }
 serde = { version = "1", optional = true }
-tokio = { version = "1.0", features = [
-    "net",
-    "rt-multi-thread",
-], optional = true }
+tokio = { version = "1.0", features = ["net"], optional = true }
 tonic = { version = "0.12", default-features = false, features = [
     "codegen",
     "prost",


### PR DESCRIPTION
It looks like even with a large number of tokio executor threads, tokio still blocks all concurrent requests if a single request is blocking.

This patch forces all potentially blocking requests to be spawned on a thread of their own using tokio's `spawn_blocking`. This applies to requests on the `Simulation` object (`step` etc) and for event sink monitoring. The latter is not a great solution yet, because any blocking event sink will also block all other request pertaining to even sinks, so it is not possible to e.g. monitor several blocking sinks concurrently.

Note that this patch makes it now possible to use tokio's single-threaded executor since the main tokio thread never block.