### PR TITLE
Allow restoring simulation after halt

### DIFF
--- a/nexosim/src/simulation.rs
+++ b/nexosim/src/simulation.rs
@@ -160,7 +160,7 @@ pub struct Simulation {
     timeout: Duration,
     observers: Vec<(String, Box<dyn ChannelObserver>)>,
     model_names: Vec<String>,
-    is_halted: Arc<AtomicBool>,
+    is_running: Arc<AtomicBool>,
     is_terminated: bool,
 }
 
@@ -176,7 +176,7 @@ impl Simulation {
         timeout: Duration,
         observers: Vec<(String, Box<dyn ChannelObserver>)>,
         model_names: Vec<String>,
-        is_halted: Arc<AtomicBool>,
+        is_running: Arc<AtomicBool>,
     ) -> Self {
         Self {
             executor,
@@ -187,7 +187,7 @@ impl Simulation {
             timeout,
             observers,
             model_names,
-            is_halted,
+            is_running,
             is_terminated: false,
         }
     }
@@ -209,6 +209,11 @@ impl Simulation {
     /// Returns the current simulation time.
     pub fn time(&self) -> MonotonicTime {
         self.time.read()
+    }
+
+    /// Reinitialize simulation's clock (eg. after halting)
+    pub fn reset_clock(&mut self, clock: impl Clock + 'static) {
+        self.clock = Box::new(clock);
     }
 
     /// Advances simulation time to that of the next scheduled event, processing
@@ -345,11 +350,6 @@ impl Simulation {
             return Err(ExecutionError::Terminated);
         }
 
-        if self.is_halted.load(Ordering::Relaxed) {
-            self.is_terminated = true;
-            return Err(ExecutionError::Halted);
-        }
-
         self.executor.run(self.timeout).map_err(|e| {
             self.is_terminated = true;
 
@@ -407,12 +407,6 @@ impl Simulation {
         if self.is_terminated {
             return Err(ExecutionError::Terminated);
         }
-
-        if self.is_halted.load(Ordering::Relaxed) {
-            self.is_terminated = true;
-            return Err(ExecutionError::Halted);
-        }
-
         // Function pulling the next action. If the action is periodic, it is
         // immediately re-scheduled.
         fn pull_next_action(scheduler_queue: &mut MutexGuard<SchedulerQueue>) -> Action {
@@ -517,7 +511,11 @@ impl Simulation {
         &mut self,
         target_time: Option<MonotonicTime>,
     ) -> Result<(), ExecutionError> {
+        self.is_running.store(true, Ordering::Relaxed);
         loop {
+            if !self.is_running.load(Ordering::Relaxed) {
+                return Err(ExecutionError::Halted);
+            }
             match self.step_to_next(target_time) {
                 // The target time was reached exactly.
                 Ok(time) if time == target_time => return Ok(()),

--- a/nexosim/src/simulation/scheduler.rs
+++ b/nexosim/src/simulation/scheduler.rs
@@ -35,9 +35,9 @@ impl Scheduler {
     pub(crate) fn new(
         scheduler_queue: Arc<Mutex<SchedulerQueue>>,
         time: AtomicTimeReader,
-        is_halted: Arc<AtomicBool>,
+        is_running: Arc<AtomicBool>,
     ) -> Self {
-        Self(GlobalScheduler::new(scheduler_queue, time, is_halted))
+        Self(GlobalScheduler::new(scheduler_queue, time, is_running))
     }
 
     /// Returns the current simulation time.
@@ -358,19 +358,19 @@ pub(crate) type SchedulerQueue = PriorityQueue<(MonotonicTime, usize), Action>;
 pub(crate) struct GlobalScheduler {
     scheduler_queue: Arc<Mutex<SchedulerQueue>>,
     time: AtomicTimeReader,
-    is_halted: Arc<AtomicBool>,
+    is_running: Arc<AtomicBool>,
 }
 
 impl GlobalScheduler {
     pub(crate) fn new(
         scheduler_queue: Arc<Mutex<SchedulerQueue>>,
         time: AtomicTimeReader,
-        is_halted: Arc<AtomicBool>,
+        is_running: Arc<AtomicBool>,
     ) -> Self {
         Self {
             scheduler_queue,
             time,
-            is_halted,
+            is_running,
         }
     }
 
@@ -564,7 +564,7 @@ impl GlobalScheduler {
 
     /// Requests the simulation to stop when advancing to the next step.
     pub(crate) fn halt(&mut self) {
-        self.is_halted.store(true, Ordering::Relaxed);
+        self.is_running.store(false, Ordering::Relaxed);
     }
 }
 

--- a/nexosim/src/simulation/sim_init.rs
+++ b/nexosim/src/simulation/sim_init.rs
@@ -20,7 +20,7 @@ pub struct SimInit {
     executor: Executor,
     scheduler_queue: Arc<Mutex<SchedulerQueue>>,
     time: AtomicTime,
-    is_halted: Arc<AtomicBool>,
+    is_running: Arc<AtomicBool>,
     clock: Box<dyn Clock + 'static>,
     clock_tolerance: Option<Duration>,
     timeout: Duration,
@@ -65,7 +65,7 @@ impl SimInit {
             executor,
             scheduler_queue: Arc::new(Mutex::new(PriorityQueue::new())),
             time,
-            is_halted: Arc::new(AtomicBool::new(false)),
+            is_running: Arc::new(AtomicBool::new(false)),
             clock: Box::new(NoClock::new()),
             clock_tolerance: None,
             timeout: Duration::ZERO,
@@ -96,7 +96,7 @@ impl SimInit {
         let scheduler = GlobalScheduler::new(
             self.scheduler_queue.clone(),
             self.time.reader(),
-            self.is_halted.clone(),
+            self.is_running.clone(),
         );
 
         add_model(
@@ -172,7 +172,7 @@ impl SimInit {
         let scheduler = Scheduler::new(
             self.scheduler_queue.clone(),
             self.time.reader(),
-            self.is_halted.clone(),
+            self.is_running.clone(),
         );
         let mut simulation = Simulation::new(
             self.executor,
@@ -183,7 +183,7 @@ impl SimInit {
             self.timeout,
             self.observers,
             self.model_names,
-            self.is_halted,
+            self.is_running,
         );
         simulation.run()?;
 

--- a/nexosim/tests/integration/main.rs
+++ b/nexosim/tests/integration/main.rs
@@ -5,6 +5,7 @@ mod model_scheduling;
 #[cfg(not(miri))]
 mod simulation_clock_sync;
 mod simulation_deadlock;
+mod simulation_halt;
 mod simulation_message_loss;
 mod simulation_no_recipient;
 mod simulation_panic;

--- a/nexosim/tests/integration/simulation_halt.rs
+++ b/nexosim/tests/integration/simulation_halt.rs
@@ -1,0 +1,91 @@
+//! Simulation pause and resume
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use nexosim::model::{Context, InitializedModel, Model};
+use nexosim::ports::{EventQueue, Output};
+use nexosim::simulation::{ExecutionError, Mailbox, SimInit, SimulationError};
+use nexosim::time::{MonotonicTime, SystemClock};
+
+struct RecurringModel {
+    pub message: Output<()>,
+    delay: Duration,
+}
+impl RecurringModel {
+    fn new(delay: Duration) -> Self {
+        Self {
+            delay,
+            message: Output::new(),
+        }
+    }
+    async fn process(&mut self) {
+        self.message.send(()).await;
+    }
+}
+impl Model for RecurringModel {
+    async fn init(self, cx: &mut Context<Self>) -> InitializedModel<Self> {
+        cx.schedule_periodic_event(self.delay, self.delay, RecurringModel::process, ())
+            .unwrap();
+        self.into()
+    }
+}
+
+#[test]
+fn halt_and_resume() -> Result<(), SimulationError> {
+    let mut model = RecurringModel::new(Duration::from_secs(2));
+    let mailbox = Mailbox::new();
+
+    let message = EventQueue::new();
+    model.message.connect_sink(&message);
+    let mut message = message.into_reader();
+
+    let t0 = MonotonicTime::EPOCH;
+
+    let (simu, mut scheduler) = SimInit::new()
+        .add_model(model, mailbox, "timed_model")
+        .set_clock(SystemClock::from_instant(t0, Instant::now()))
+        .init(t0)?;
+
+    let simulation = Arc::new(Mutex::new(simu));
+    let spawned_simulation = simulation.clone();
+
+    thread::spawn(move || spawned_simulation.lock().unwrap().step_unbounded());
+
+    thread::sleep(Duration::from_secs(1));
+
+    scheduler.halt();
+    thread::sleep(Duration::from_secs(1));
+
+    // assert that the step has completed, even though `pause` was called before it's scheduled time
+    assert!(message.next().is_some());
+
+    thread::sleep(Duration::from_secs(3));
+
+    // halted - no new messages
+    assert!(message.next().is_none());
+
+    {
+        let mut s = simulation.lock().unwrap();
+        let t = s.time();
+        s.reset_clock(SystemClock::from_instant(t, Instant::now()));
+    }
+    let spawned_simulation = simulation.clone();
+    let simulation_handle =
+        thread::spawn(move || spawned_simulation.lock().unwrap().step_unbounded());
+
+    thread::sleep(Duration::from_secs(1));
+    // // now new messages yet, as the halted time should be invisible to the scheduler
+    assert!(message.next().is_none());
+
+    thread::sleep(Duration::from_secs(2));
+    assert!(message.next().is_some());
+
+    scheduler.halt();
+
+    match simulation_handle.join().unwrap() {
+        Err(ExecutionError::Halted) => Ok(()),
+        Err(e) => Err(e.into()),
+        _ => Ok(()),
+    }
+}


### PR DESCRIPTION
`is_halted` is renamed to `is_running`. Setting to `false` acts a request to stop the simulation. It is set and checked only in looping step methods.
Added `reset_clock` method to reinitialize simulation's clock - before it is resumed.