### PR TITLE
Enable time in tokio runtime builder

### DIFF
--- a/nexosim/src/server/run.rs
+++ b/nexosim/src/server/run.rs
@@ -68,6 +68,7 @@ fn run_service(
     signal: Option<Pin<Box<dyn Future<Output = ()>>>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
         .enable_io()
         .build()?;
 
@@ -170,6 +171,7 @@ fn run_local_service(
     fs::create_dir_all(path.parent().unwrap())?;
 
     let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
         .enable_io()
         .build()?;
 

--- a/nexosim/src/util/task_set.rs
+++ b/nexosim/src/util/task_set.rs
@@ -217,7 +217,7 @@ impl TaskSet {
     ///
     /// This method will panic if there is no active task with the provided
     /// index.
-    pub(crate) fn waker_of(&self, idx: usize) -> WakerRef {
+    pub(crate) fn waker_of(&self, idx: usize) -> WakerRef<'_> {
         assert!(idx < self.task_count);
 
         waker_ref(&self.tasks[idx])


### PR DESCRIPTION
This feature is required when received gRPC requests include a timeout parameter. Without tokio time enabled such a request would cause server panic.